### PR TITLE
FIX: Remove update_attributes! which is deprecated in Rails 6.0.0

### DIFF
--- a/app/jobs/onceoff/fix_invalid_date_of_birth.rb
+++ b/app/jobs/onceoff/fix_invalid_date_of_birth.rb
@@ -11,7 +11,7 @@ module Jobs
         begin
           Date.parse(custom_field.value)
         rescue ArgumentError
-          custom_field.update_attributes!(value: '')
+          custom_field.update!(value: '')
         end
       end
     end

--- a/app/jobs/onceoff/migrate_date_of_birth_to_users_table.rb
+++ b/app/jobs/onceoff/migrate_date_of_birth_to_users_table.rb
@@ -16,7 +16,7 @@ module Jobs
             # Just drop migration of custom field
           end
 
-          custom_field.user.update_attributes!(date_of_birth: date)
+          custom_field.user.update!(date_of_birth: date)
         else
           custom_field.destroy!
         end


### PR DESCRIPTION
An easy fix to remove the warning in Rails 6.0.0