### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/onceoff/fix_invalid_date_of_birth.rb
+++ b/app/jobs/onceoff/fix_invalid_date_of_birth.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class FixInvalidDateOfBirth < Jobs::Onceoff
+  class FixInvalidDateOfBirth < ::Jobs::Onceoff
     def execute_onceoff(args)
       UserCustomField
         .where(name: 'date_of_birth')

--- a/app/jobs/onceoff/migrate_date_of_birth_to_users_table.rb
+++ b/app/jobs/onceoff/migrate_date_of_birth_to_users_table.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class MigrateDateOfBirthToUsersTable < Jobs::Onceoff
+  class MigrateDateOfBirthToUsersTable < ::Jobs::Onceoff
     def execute_onceoff(args)
       UserCustomField
         .where(name: 'date_of_birth')


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364