### PR TITLE
FIX: Don't disable birthday emojis when cakeday is disabled.

### DIFF
--- a/app/controllers/discourse_cakeday/anniversaries_controller.rb
+++ b/app/controllers/discourse_cakeday/anniversaries_controller.rb
@@ -2,6 +2,8 @@
 
 module DiscourseCakeday
   class AnniversariesController < CakedayController
+    before_action :ensure_cakeday_enabled
+
     PAGE_SIZE = 48
 
     def index
@@ -57,6 +59,12 @@ module DiscourseCakeday
           timezone_offset: params[:timezone_offset]
         )
       )
+    end
+
+    private
+
+    def ensure_cakeday_enabled
+      raise Discourse::NotFound if !SiteSetting.cakeday_enabled
     end
   end
 end

--- a/app/controllers/discourse_cakeday/birthdays_controller.rb
+++ b/app/controllers/discourse_cakeday/birthdays_controller.rb
@@ -2,6 +2,8 @@
 
 module DiscourseCakeday
   class BirthdaysController < CakedayController
+    before_action :ensure_cakeday_birthday_enabled
+
     PAGE_SIZE = 48
 
     def index
@@ -48,6 +50,12 @@ module DiscourseCakeday
           filter: params[:filter]
         )
       )
+    end
+
+    private
+
+    def ensure_cakeday_birthday_enabled
+      raise Discourse::NotFound if !SiteSetting.cakeday_birthday_enabled
     end
   end
 end

--- a/app/controllers/discourse_cakeday/cakeday_controller.rb
+++ b/app/controllers/discourse_cakeday/cakeday_controller.rb
@@ -4,7 +4,6 @@ module DiscourseCakeday
   class CakedayController < ::ApplicationController
     before_action :ensure_logged_in
     before_action :setup_params
-    requires_plugin DiscourseCakeday::PLUGIN_NAME
 
     private
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,8 +6,6 @@
 # authors: Alan Tan
 # url: https://github.com/discourse/discourse-cakeday
 
-enabled_site_setting :cakeday_enabled
-
 register_asset 'stylesheets/cakeday.scss'
 register_asset 'stylesheets/emoji-images.scss'
 register_asset 'stylesheets/mobile/user-date-of-birth-input.scss'
@@ -65,7 +63,7 @@ after_initialize do
   end
 
   add_to_serializer(:user_card, :include_date_of_birth?) do
-    SiteSetting.cakeday_enabled && scope.user.present?
+    SiteSetting.cakeday_birthday_enabled && scope.user.present?
   end
 
   require_dependency 'post_serializer'
@@ -82,7 +80,7 @@ after_initialize do
     end
 
     def include_user_date_of_birth?
-      SiteSetting.cakeday_enabled && scope.user.present?
+      SiteSetting.cakeday_birthday_enabled && scope.user.present?
     end
 
     def user_date_of_birth

--- a/spec/integration/cakeday_spec.rb
+++ b/spec/integration/cakeday_spec.rb
@@ -11,27 +11,27 @@ describe "Cakeyday" do
   end
 
   describe 'when logged in' do
+    let(:time) { Time.zone.local(2016, 9, 30) }
+
     before do
       sign_in(Fabricate(:user, created_at: time - 10.days))
     end
 
-    describe "when plugin disabled" do
-      before { SiteSetting.cakeday_enabled = false }
-      let(:time) { Time.zone.local(2016, 9, 30) }
+    it "should return 404 when viewing users anniversaries if cakeday_enabled is false" do
+      SiteSetting.cakeday_enabled = false
 
-      it "doesn't respond" do
-        get "/cakeday/anniversaries.json"
-        expect(response.status).to eq(404)
+      get "/cakeday/anniversaries.json"
+      expect(response.status).to eq(404)
+    end
 
-        get "/cakeday/birthdays.json"
-        expect(response.status).to eq(404)
-      end
+    it "should return 404 when viewing users birthdays if cakeday_birthday_enabled is false" do
+      SiteSetting.cakeday_birthday_enabled = false
 
+      get "/cakeday/birthdays.json"
+      expect(response.status).to eq(404)
     end
 
     describe "when viewing users anniversaries" do
-      let(:time) { Time.zone.local(2016, 9, 30) }
-
       it "should return the right payload" do
         freeze_time(time) do
           created_at = time - 1.year

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -14,13 +14,16 @@ RSpec.describe PostSerializer do
       expect(serializer.as_json[:user_created_at]).to eq(user.created_at)
     end
 
-    context 'with plugin disabled' do
-      before { SiteSetting.cakeday_enabled = false }
+    it "should not include the user's created at date when cakeday_enabled is false" do
+      SiteSetting.cakeday_enabled = false
 
-      it "should not include the user's date of birth" do
-        expect(serializer.as_json.has_key?(:user_date_of_birth)).to eq(false)
-        expect(serializer.as_json.has_key?(:user_created_at)).to eq(false)
-      end
+      expect(serializer.as_json.has_key?(:user_created_at)).to eq(false)
+    end
+
+    it "should not include the user's date of birth when cakeday_birthday_enabled is false" do
+      SiteSetting.cakeday_birthday_enabled = false
+
+      expect(serializer.as_json.has_key?(:user_date_of_birth)).to eq(false)
     end
   end
 

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -12,12 +12,10 @@ RSpec.describe UserSerializer do
       expect(serializer.as_json[:date_of_birth]).to eq(user.date_of_birth)
     end
 
-    context 'with plugin disabled' do
-      before { SiteSetting.cakeday_enabled = false }
+    it "should not include the user's date of birth when cakeday_birthday_enabled is false" do
+      SiteSetting.cakeday_birthday_enabled = false
 
-      it "should not include the user's date of birth" do
-        expect(serializer.as_json[:date_of_birth]).to eq(nil)
-      end
+      expect(serializer.as_json[:date_of_birth]).to eq(nil)
     end
   end
 


### PR DESCRIPTION
The plugin is controlled via two site settings `cakeday_enabled` and
`cakeday_birthday_enabled`. In 7da144143a937d51de9b6f5456b3ac45ce6b7682,
birthday emojis were disabled when cakeday was disabled which is
incorrect.