### PR TITLE
FEATURE: Separate sidebar links for anniv and bday

### DIFF
--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -156,24 +156,20 @@ function initializeCakeday(api) {
     });
 
     if (cakedayEnabled) {
-      api.decorateWidget("hamburger-menu:generalLinks", () => {
-
-        return {
-          "cakeday.anniversaries.today",
-          label: "anniversaries.title",
-          className: "cakeday-link",
-        };
+      api.addCommunitySectionLink({
+        name: "anniversaries",
+        route: "cakeday.anniversaries.today",
+        title: I18n.t("anniversaries.title"),
+        text: I18n.t("anniversaries.title")
       });
     }
 
     if (cakedayBirthdayEnabled) {
-      api.decorateWidget("hamburger-menu:generalLinks", () => {
-
-        return {
-          "cakeday.birthdays.today",
-          label: "birthdays.title",
-          className: "cakeday-link",
-        };
+      api.addCommunitySectionLink({
+        name: "birthdays",
+        route: "cakeday.birthdays.today",
+        title: I18n.t("birthdays.title"),
+        text: I18n.t("birthdays.title")
       });
     }
   }

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -155,21 +155,29 @@ function initializeCakeday(api) {
       }
     });
 
-    api.decorateWidget("hamburger-menu:generalLinks", () => {
-      let route;
+    if (cakedayEnabled) {
+      api.decorateWidget("hamburger-menu:generalLinks", () => {
+        let route = "cakeday.anniversaries.today";
 
-      if (cakedayEnabled) {
-        route = "cakeday.anniversaries.today";
-      } else if (cakedayBirthdayEnabled) {
-        route = "cakeday.birthdays.today";
-      }
+        return {
+          route,
+          label: "anniversaries.title",
+          className: "cakeday-link",
+        };
+      });
+    }
 
-      return {
-        route,
-        label: "cakeday.title",
-        className: "cakeday-link",
-      };
-    });
+    if (cakedayBirthdayEnabled) {
+      api.decorateWidget("hamburger-menu:generalLinks", () => {
+        let route = "cakeday.birthdays.today";
+
+        return {
+          route,
+          label: "birthdays.title",
+          className: "cakeday-link",
+        };
+      });
+    }
   }
 }
 

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -161,7 +161,7 @@ function initializeCakeday(api) {
           name: "anniversaries",
           route: "cakeday.anniversaries.today",
           title: I18n.t("anniversaries.title"),
-          text: I18n.t("anniversaries.title")
+          text: I18n.t("anniversaries.title"),
         });
       }
 
@@ -170,7 +170,7 @@ function initializeCakeday(api) {
           name: "birthdays",
           route: "cakeday.birthdays.today",
           title: I18n.t("birthdays.title"),
-          text: I18n.t("birthdays.title")
+          text: I18n.t("birthdays.title"),
         });
       }
     } else {

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -157,10 +157,9 @@ function initializeCakeday(api) {
 
     if (cakedayEnabled) {
       api.decorateWidget("hamburger-menu:generalLinks", () => {
-        let route = "cakeday.anniversaries.today";
 
         return {
-          route,
+          "cakeday.anniversaries.today",
           label: "anniversaries.title",
           className: "cakeday-link",
         };
@@ -169,10 +168,9 @@ function initializeCakeday(api) {
 
     if (cakedayBirthdayEnabled) {
       api.decorateWidget("hamburger-menu:generalLinks", () => {
-        let route = "cakeday.birthdays.today";
 
         return {
-          route,
+          "cakeday.birthdays.today",
           label: "birthdays.title",
           className: "cakeday-link",
         };

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -155,21 +155,39 @@ function initializeCakeday(api) {
       }
     });
 
-    if (cakedayEnabled) {
-      api.addCommunitySectionLink({
-        name: "anniversaries",
-        route: "cakeday.anniversaries.today",
-        title: I18n.t("anniversaries.title"),
-        text: I18n.t("anniversaries.title")
-      });
-    }
+    if (siteSettings.enable_experimental_sidebar_hamburger) {
+      if (cakedayEnabled) {
+        api.addCommunitySectionLink({
+          name: "anniversaries",
+          route: "cakeday.anniversaries.today",
+          title: I18n.t("anniversaries.title"),
+          text: I18n.t("anniversaries.title")
+        });
+      }
 
-    if (cakedayBirthdayEnabled) {
-      api.addCommunitySectionLink({
-        name: "birthdays",
-        route: "cakeday.birthdays.today",
-        title: I18n.t("birthdays.title"),
-        text: I18n.t("birthdays.title")
+      if (cakedayBirthdayEnabled) {
+        api.addCommunitySectionLink({
+          name: "birthdays",
+          route: "cakeday.birthdays.today",
+          title: I18n.t("birthdays.title"),
+          text: I18n.t("birthdays.title")
+        });
+      }
+    } else {
+      api.decorateWidget("hamburger-menu:generalLinks", () => {
+        let route;
+
+        if (cakedayEnabled) {
+          route = "cakeday.anniversaries.today";
+        } else if (cakedayBirthdayEnabled) {
+          route = "cakeday.birthdays.today";
+        }
+
+        return {
+          route,
+          label: "cakeday.title",
+          className: "cakeday-link",
+        };
       });
     }
   }

--- a/test/javascripts/acceptance/cakeday-sidebar-test.js
+++ b/test/javascripts/acceptance/cakeday-sidebar-test.js
@@ -57,8 +57,12 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/cakeday/anniversaries", () => helper.response(cloneJSON(anniversariesFixtures)));
-    server.get("/cakeday/birthdays", () => helper.response(cloneJSON(birthdaysFixtures)));
+    server.get("/cakeday/anniversaries", () =>
+      helper.response(cloneJSON(anniversariesFixtures))
+    );
+    server.get("/cakeday/birthdays", () =>
+      helper.response(cloneJSON(birthdaysFixtures))
+    );
   });
 
   test("clicking on anniversaries link", async function (assert) {
@@ -82,7 +86,11 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
 
     await click(".sidebar-section-link-anniversaries");
 
-    assert.strictEqual(currentURL(), "/cakeday/anniversaries/today", "it navigates to the right page");
+    assert.strictEqual(
+      currentURL(),
+      "/cakeday/anniversaries/today",
+      "it navigates to the right page"
+    );
   });
 
   test("clicking on birthdays link", async function (assert) {
@@ -106,6 +114,10 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
 
     await click(".sidebar-section-link-birthdays");
 
-    assert.strictEqual(currentURL(), "/cakeday/birthdays/today", "it navigates to the right page");
+    assert.strictEqual(
+      currentURL(),
+      "/cakeday/birthdays/today",
+      "it navigates to the right page"
+    );
   });
 });

--- a/test/javascripts/acceptance/cakeday-sidebar-test.js
+++ b/test/javascripts/acceptance/cakeday-sidebar-test.js
@@ -1,0 +1,111 @@
+import { test } from "qunit";
+import I18n from "I18n";
+import { click, currentURL, visit } from "@ember/test-helpers";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import anniversariesFixtures from "../fixtures/anniversaries";
+import birthdaysFixtures from "../fixtures/birthdays";
+import { cloneJSON } from "discourse-common/lib/object";
+
+acceptance("Cakeday - Sidebar with cakeday disabled", function (needs) {
+  needs.user();
+
+  needs.settings({
+    cakeday_enabled: false,
+    enable_experimental_sidebar_hamburger: true,
+    enable_sidebar: true,
+  });
+
+  test("anniversaries sidebar link is hidden", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.ok(
+      !exists(".sidebar-section-link-anniversaries"),
+      "it does not display the anniversaries link in sidebar"
+    );
+  });
+
+  test("birthdays sidebar link is hidden", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.ok(
+      !exists(".sidebar-section-link-birthdays"),
+      "it does not display the birthdays link in sidebar"
+    );
+  });
+});
+
+acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
+  needs.user();
+
+  needs.settings({
+    cakeday_enabled: true,
+    cakeday_birthday_enabled: true,
+    enable_experimental_sidebar_hamburger: true,
+    enable_sidebar: true,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/cakeday/anniversaries", () => helper.response(cloneJSON(anniversariesFixtures)));
+    server.get("/cakeday/birthdays", () => helper.response(cloneJSON(birthdaysFixtures)));
+  });
+
+  test("clicking on anniversaries link", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.strictEqual(
+      query(".sidebar-section-link-anniversaries").textContent.trim(),
+      I18n.t("anniversaries.title"),
+      "displays the right text for the link"
+    );
+
+    assert.strictEqual(
+      query(".sidebar-section-link-anniversaries").title,
+      I18n.t("anniversaries.title"),
+      "displays the right title for the link"
+    );
+
+    await click(".sidebar-section-link-anniversaries");
+
+    assert.strictEqual(currentURL(), "/cakeday/anniversaries/today", "it navigates to the right page");
+  });
+
+  test("clicking on birthdays link", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.strictEqual(
+      query(".sidebar-section-link-birthdays").textContent.trim(),
+      I18n.t("birthdays.title"),
+      "displays the right text for the link"
+    );
+
+    assert.strictEqual(
+      query(".sidebar-section-link-birthdays").title,
+      I18n.t("birthdays.title"),
+      "displays the right title for the link"
+    );
+
+    await click(".sidebar-section-link-birthdays");
+
+    assert.strictEqual(currentURL(), "/cakeday/birthdays/today", "it navigates to the right page");
+  });
+});

--- a/test/javascripts/fixtures/anniversaries.js
+++ b/test/javascripts/fixtures/anniversaries.js
@@ -1,3 +1,6 @@
 export default {
-  "anniversaries":[],"total_rows_anniversaries":0,"load_more_anniversaries":"/cakeday/anniversaries?filter=today&page=1&timezone_offset=360"
+  anniversaries: [],
+  total_rows_anniversaries: 0,
+  load_more_anniversaries:
+    "/cakeday/anniversaries?filter=today&page=1&timezone_offset=360",
 };

--- a/test/javascripts/fixtures/anniversaries.js
+++ b/test/javascripts/fixtures/anniversaries.js
@@ -1,0 +1,3 @@
+export default {
+  "anniversaries":[],"total_rows_anniversaries":0,"load_more_anniversaries":"/cakeday/anniversaries?filter=today&page=1&timezone_offset=360"
+};

--- a/test/javascripts/fixtures/birthdays.js
+++ b/test/javascripts/fixtures/birthdays.js
@@ -1,0 +1,3 @@
+export default {
+  "birthdays":[],"total_rows_birthdays":0,"load_more_birthdays":"/cakeday/birthdays?filter=today&page=1"
+};

--- a/test/javascripts/fixtures/birthdays.js
+++ b/test/javascripts/fixtures/birthdays.js
@@ -1,3 +1,5 @@
 export default {
-  "birthdays":[],"total_rows_birthdays":0,"load_more_birthdays":"/cakeday/birthdays?filter=today&page=1"
+  birthdays: [],
+  total_rows_birthdays: 0,
+  load_more_birthdays: "/cakeday/birthdays?filter=today&page=1",
 };


### PR DESCRIPTION
Instead of a single link titled "Cakeday" there will now be two links
added to the sidebar: "Anniversary" and "Birthday".

![image](https://user-images.githubusercontent.com/1490496/195451318-2ca049e9-68de-4246-95e5-73b7e10e6282.png)

I didn't add any tests because there aren't any existing tests for sidebar links and because it is *just* using the discourse core api `api.decorateWidget`. 

Also looks like the `api.addCommunitySectionLink` api is still marked EXPERIMENTAL so I didn't use it.