### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/cakeday-sidebar-test.js
+++ b/test/javascripts/acceptance/cakeday-sidebar-test.js
@@ -15,6 +15,7 @@ acceptance("Cakeday - Sidebar with cakeday disabled", function (needs) {
 
   needs.settings({
     cakeday_enabled: false,
+    cakeday_birthday_enabled: false,
     enable_experimental_sidebar_hamburger: true,
     enable_sidebar: true,
   });


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.