### PR TITLE
SYNTAX:  Remove whitespace

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-card-post-names/user-card-cakeday.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-card-post-names/user-card-cakeday.hbs
@@ -3,7 +3,6 @@
     {{emoji-images list=siteSettings.cakeday_birthday_emoji title=cakedayBirthdayTitle}}
   {{/if}}
 {{/if}}
-
 {{#if siteSettings.cakeday_enabled}}
   {{#if isCakeday}}
     {{emoji-images list=siteSettings.cakeday_emoji title=cakedayTitle}}


### PR DESCRIPTION
Whitespace in this template when empty causes `:empty` css target not to work.