### PR TITLE
FIX: Backwards compatibility of plugin against the stable branch

### DIFF
--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -155,7 +155,10 @@ function initializeCakeday(api) {
       }
     });
 
-    if (siteSettings.navigation_menu !== "legacy") {
+    if (
+      siteSettings.navigation_menu !== "legacy" &&
+      api.addCommunitySectionLink
+    ) {
       if (cakedayEnabled) {
         api.addCommunitySectionLink({
           name: "anniversaries",


### PR DESCRIPTION
There is no tests I can write which would catch this problem. Instead we need plugin tests to run against both the `main` and `stable` branches as well. 