### PR TITLE
FIX: respect prioritize_username_in_ux site setting

### DIFF
--- a/app/controllers/discourse_cakeday/cakeday_controller.rb
+++ b/app/controllers/discourse_cakeday/cakeday_controller.rb
@@ -57,11 +57,19 @@ module DiscourseCakeday
 
       total = @users.count
 
+      # when the cakedate is the same, we order based on how the data is displayed
+      tie_breaker =
+        if SiteSetting.prioritize_username_in_ux
+          :username_lower
+        else
+          "COALESCE(NULLIF(LOWER(TRIM(name)), ''), username_lower) ASC"
+        end
+
       @users =
         @users
           .select(:id, :username, :name, :title, :uploaded_avatar_id, "#{column_sql} cakedate")
           .order("TO_CHAR(#{column_sql}, 'MMDDYYYY') ASC")
-          .order(:username_lower)
+          .order(tie_breaker)
           .limit(PAGE_SIZE)
           .offset(PAGE_SIZE * @page)
 

--- a/spec/integration/cakeday_spec.rb
+++ b/spec/integration/cakeday_spec.rb
@@ -121,6 +121,29 @@ describe "Anniversaries and Birthdays" do
           expect(body["birthdays"].map { |u| u["id"] }).to eq [user5.id]
         end
       end
+
+      it "respects the prioritize_username_in_ux site setting" do
+        freeze_time(time) do
+          dob = "1904-9-30"
+          user1 = Fabricate(:user, username: "alpha_zeta", name: "Zeta Alpha", date_of_birth: dob)
+          user2 = Fabricate(:user, username: "zeta_alpha", name: "Alpha Zeta", date_of_birth: dob)
+          user3 = Fabricate(:user, username: "beta_omega", name: "", date_of_birth: dob)
+
+          SiteSetting.prioritize_username_in_ux = true
+
+          get "/cakeday/birthdays.json", params: { filter: "today" }
+
+          body = JSON.parse(response.body)
+          expect(body["birthdays"].map { |u| u["id"] }).to eq [user1.id, user3.id, user2.id]
+
+          SiteSetting.prioritize_username_in_ux = false
+
+          get "/cakeday/birthdays.json", params: { filter: "today" }
+
+          body = JSON.parse(response.body)
+          expect(body["birthdays"].map { |u| u["id"] }).to eq [user2.id, user3.id, user1.id]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We want to sort the results based on the information available and displayed in the UI.

The `prioritize_username_in_ux` site setting changes the way we show the username and names, so we need to account for its value when sorting when the cakedate is the same for several users.

The `tie_breaker` sort is quite a mouthful when we don't prioritize username, but it's ensuring we lower the name (because postgresql `order by` is case sensitive), then it trims the value and coalesces it to `username_lower` if the user hasn't provided a name yet.