### PR TITLE
FIX: prefix columns with table name to prevent ambiguous column errors

### DIFF
--- a/app/controllers/discourse_cakeday/cakeday_controller.rb
+++ b/app/controllers/discourse_cakeday/cakeday_controller.rb
@@ -62,7 +62,7 @@ module DiscourseCakeday
         if SiteSetting.prioritize_username_in_ux
           :username_lower
         else
-          "COALESCE(NULLIF(LOWER(TRIM(name)), ''), username_lower) ASC"
+          "COALESCE(NULLIF(LOWER(TRIM(users.name)), ''), users.username_lower) ASC"
         end
 
       @users =


### PR DESCRIPTION
Prefix the columns we use for sorting the cakedays with the `users` table so they don't clash with columns with the same name in other tables.

No tests were added / changed since the issue happens when another plugin overrides the query and, for example, joins with the `user_custom_fields` table which also has a `name` column 🤦