### PR TITLE
DEV: Fix flaky test

### DIFF
--- a/spec/integration/cakeday_spec.rb
+++ b/spec/integration/cakeday_spec.rb
@@ -79,12 +79,12 @@ describe "Anniversaries and Birthdays" do
           get "/cakeday/anniversaries.json", params: { filter: "today" }
 
           body = JSON.parse(response.body)
-          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly [user1.id, user2.id]
+          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly(user1.id, user2.id)
 
           get "/cakeday/anniversaries.json", params: { filter: "tomorrow" }
 
           body = JSON.parse(response.body)
-          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly [user3.id, user4.id]
+          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly(user3.id, user4.id)
         end
       end
     end

--- a/spec/integration/cakeday_spec.rb
+++ b/spec/integration/cakeday_spec.rb
@@ -79,12 +79,12 @@ describe "Anniversaries and Birthdays" do
           get "/cakeday/anniversaries.json", params: { filter: "today" }
 
           body = JSON.parse(response.body)
-          expect(body["anniversaries"].map { |u| u["id"] }).to eq [user1.id, user2.id]
+          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly [user1.id, user2.id]
 
           get "/cakeday/anniversaries.json", params: { filter: "tomorrow" }
 
           body = JSON.parse(response.body)
-          expect(body["anniversaries"].map { |u| u["id"] }).to eq [user3.id, user4.id]
+          expect(body["anniversaries"].map { |u| u["id"] }).to contain_exactly [user3.id, user4.id]
         end
       end
     end


### PR DESCRIPTION
When anniversary dates match, result ordering from this endpoint is decided based on name/username, and can therefore vary based on user fabrication. All we care about for this test is that the correct users are shown on the correct day.