### PR TITLE
UX: Add birthday cake icon when adding link to sidebar

### DIFF
--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -89,6 +89,7 @@ function initializeCakeday(api) {
           route: "cakeday.anniversaries.today",
           title: I18n.t("anniversaries.title"),
           text: I18n.t("anniversaries.title"),
+          icon: "birthday-cake",
         });
       }
 
@@ -98,6 +99,7 @@ function initializeCakeday(api) {
           route: "cakeday.birthdays.today",
           title: I18n.t("birthdays.title"),
           text: I18n.t("birthdays.title"),
+          icon: "birthday-cake",
         });
       }
     } else {

--- a/test/javascripts/acceptance/cakeday-sidebar-test.js
+++ b/test/javascripts/acceptance/cakeday-sidebar-test.js
@@ -85,6 +85,13 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
       "displays the right title for the link"
     );
 
+    assert.ok(
+      exists(
+        ".sidebar-section-link[data-link-name='anniversaries'] .sidebar-section-link-prefix.icon .d-icon-birthday-cake"
+      ),
+      "displays the birthday-cake icon for the link"
+    );
+
     await click(".sidebar-section-link[data-link-name='anniversaries']");
 
     assert.strictEqual(
@@ -113,6 +120,13 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
       query(".sidebar-section-link[data-link-name='birthdays']").title,
       I18n.t("birthdays.title"),
       "displays the right title for the link"
+    );
+
+    assert.ok(
+      exists(
+        ".sidebar-section-link[data-link-name='birthdays'] .sidebar-section-link-prefix.icon .d-icon-birthday-cake"
+      ),
+      "displays the birthday-cake icon for the link"
     );
 
     await click(".sidebar-section-link[data-link-name='birthdays']");


### PR DESCRIPTION
Now that Discourse core supports custom icons for each link, we can
specify the icon we want for the plugin.