### PR TITLE
DEV: Remove decoration for legacy hamburger menu

### DIFF
--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -68,44 +68,23 @@ function initializeCakeday(api) {
   }
 
   if (cakedayEnabled || birthdayEnabled) {
-    if (
-      siteSettings.navigation_menu !== "legacy" &&
-      api.addCommunitySectionLink
-    ) {
-      if (cakedayEnabled) {
-        api.addCommunitySectionLink({
-          name: "anniversaries",
-          route: "cakeday.anniversaries.today",
-          title: I18n.t("anniversaries.title"),
-          text: I18n.t("anniversaries.title"),
-          icon: "birthday-cake",
-        });
-      }
+    if (cakedayEnabled) {
+      api.addCommunitySectionLink({
+        name: "anniversaries",
+        route: "cakeday.anniversaries.today",
+        title: I18n.t("anniversaries.title"),
+        text: I18n.t("anniversaries.title"),
+        icon: "birthday-cake",
+      });
+    }
 
-      if (birthdayEnabled) {
-        api.addCommunitySectionLink({
-          name: "birthdays",
-          route: "cakeday.birthdays.today",
-          title: I18n.t("birthdays.title"),
-          text: I18n.t("birthdays.title"),
-          icon: "birthday-cake",
-        });
-      }
-    } else {
-      api.decorateWidget("hamburger-menu:generalLinks", () => {
-        let route;
-
-        if (cakedayEnabled) {
-          route = "cakeday.anniversaries.today";
-        } else if (birthdayEnabled) {
-          route = "cakeday.birthdays.today";
-        }
-
-        return {
-          route,
-          label: "cakeday.title",
-          className: "cakeday-link",
-        };
+    if (birthdayEnabled) {
+      api.addCommunitySectionLink({
+        name: "birthdays",
+        route: "cakeday.birthdays.today",
+        title: I18n.t("birthdays.title"),
+        text: I18n.t("birthdays.title"),
+        icon: "birthday-cake",
       });
     }
   }


### PR DESCRIPTION
The `legacy` option has been removed from the `navigation_menu` site setting, so we can remove all the logic that's related to the `legacy` option from this plugin.

Internal topic: t/113137.