### PR TITLE
FIX: move birthdays and anniversaries links to more section

### DIFF
--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -77,7 +77,7 @@ function initializeCakeday(api) {
           text: I18n.t("anniversaries.title"),
           icon: "birthday-cake",
         },
-        "true"
+        true
       );
     }
 
@@ -90,7 +90,7 @@ function initializeCakeday(api) {
           text: I18n.t("birthdays.title"),
           icon: "birthday-cake",
         },
-        "true"
+        true
       );
     }
   }

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -69,23 +69,29 @@ function initializeCakeday(api) {
 
   if (cakedayEnabled || birthdayEnabled) {
     if (cakedayEnabled) {
-      api.addCommunitySectionLink({
-        name: "anniversaries",
-        route: "cakeday.anniversaries.today",
-        title: I18n.t("anniversaries.title"),
-        text: I18n.t("anniversaries.title"),
-        icon: "birthday-cake",
-      });
+      api.addCommunitySectionLink(
+        {
+          name: "anniversaries",
+          route: "cakeday.anniversaries.today",
+          title: I18n.t("anniversaries.title"),
+          text: I18n.t("anniversaries.title"),
+          icon: "birthday-cake",
+        },
+        "true"
+      );
     }
 
     if (birthdayEnabled) {
-      api.addCommunitySectionLink({
-        name: "birthdays",
-        route: "cakeday.birthdays.today",
-        title: I18n.t("birthdays.title"),
-        text: I18n.t("birthdays.title"),
-        icon: "birthday-cake",
-      });
+      api.addCommunitySectionLink(
+        {
+          name: "birthdays",
+          route: "cakeday.birthdays.today",
+          title: I18n.t("birthdays.title"),
+          text: I18n.t("birthdays.title"),
+          icon: "birthday-cake",
+        },
+        "true"
+      );
     }
   }
 }


### PR DESCRIPTION
After this fix, we need a secondary argument to move `birthdays` and `anniversaries` links to more section.

https://github.com/discourse/discourse/pull/28135