### PR TITLE
DEV: update deprecated icon name birthday-cake to cake-candles

### DIFF
--- a/assets/javascripts/discourse/components/emoji-images.hbs
+++ b/assets/javascripts/discourse/components/emoji-images.hbs
@@ -5,5 +5,5 @@
     {{/each}}
   </div>
 {{else}}
-  {{d-icon "birthday-cake" title=this.titleText}}
+  {{d-icon "cake-candles" title=this.titleText}}
 {{/if}}

--- a/assets/javascripts/discourse/initializers/cakeday.js
+++ b/assets/javascripts/discourse/initializers/cakeday.js
@@ -29,7 +29,7 @@ function initializeCakeday(api) {
         if (emojiEnabled) {
           result.emoji = siteSettings.cakeday_emoji;
         } else {
-          result.icon = "birthday-cake";
+          result.icon = "cake-candles";
         }
 
         if (user_id === currentUser?.id) {
@@ -53,7 +53,7 @@ function initializeCakeday(api) {
         if (emojiEnabled) {
           result.emoji = siteSettings.cakeday_birthday_emoji;
         } else {
-          result.icon = "birthday-cake";
+          result.icon = "cake-candles";
         }
 
         if (user_id === currentUser?.id) {
@@ -75,7 +75,7 @@ function initializeCakeday(api) {
           route: "cakeday.anniversaries.today",
           title: I18n.t("anniversaries.title"),
           text: I18n.t("anniversaries.title"),
-          icon: "birthday-cake",
+          icon: "cake-candles",
         },
         true
       );
@@ -88,7 +88,7 @@ function initializeCakeday(api) {
           route: "cakeday.birthdays.today",
           title: I18n.t("birthdays.title"),
           text: I18n.t("birthdays.title"),
-          icon: "birthday-cake",
+          icon: "cake-candles",
         },
         true
       );

--- a/test/javascripts/acceptance/cakeday-sidebar-test.js
+++ b/test/javascripts/acceptance/cakeday-sidebar-test.js
@@ -82,7 +82,7 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
 
     assert
       .dom(
-        ".sidebar-section-link[data-link-name='anniversaries'] .sidebar-section-link-prefix.icon .d-icon-birthday-cake"
+        ".sidebar-section-link[data-link-name='anniversaries'] .sidebar-section-link-prefix.icon .d-icon-cake-candles"
       )
       .exists("displays the birthday-cake icon for the link");
 
@@ -119,7 +119,7 @@ acceptance("Cakeday - Sidebar with cakeday enabled", function (needs) {
 
     assert
       .dom(
-        ".sidebar-section-link[data-link-name='birthdays'] .sidebar-section-link-prefix.icon .d-icon-birthday-cake"
+        ".sidebar-section-link[data-link-name='birthdays'] .sidebar-section-link-prefix.icon .d-icon-cake-candles"
       )
       .exists("displays the birthday-cake icon for the link");
 


### PR DESCRIPTION
This PR updates the deprecated birthday-cake icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.