### PR TITLE
DEV: Persist the current default of `cakeday_enabled`

### DIFF
--- a/db/migrate/20250717093505_persist_cakeday_enabled.rb
+++ b/db/migrate/20250717093505_persist_cakeday_enabled.rb
@@ -3,9 +3,9 @@
 class PersistCakedayEnabled < ActiveRecord::Migration[7.2]
   def up
     # 5 is bool data_type
-    DB.exec <<~SQL
+    DB.exec(<<~SQL, value: SiteSetting.cakeday_enabled ? "t" : "f")
       INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
-      VALUES('cakeday_enabled', 5, 't', NOW(), NOW())
+      VALUES('cakeday_enabled', 5, :value, NOW(), NOW())
       ON CONFLICT (name) DO NOTHING
     SQL
   end

--- a/db/migrate/20250717093505_persist_cakeday_enabled.rb
+++ b/db/migrate/20250717093505_persist_cakeday_enabled.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO: Comment this migration out when merging the plugin into core
 class PersistCakedayEnabled < ActiveRecord::Migration[7.2]
   def up
     # 5 is bool data_type

--- a/db/migrate/20250717093505_persist_cakeday_enabled.rb
+++ b/db/migrate/20250717093505_persist_cakeday_enabled.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PersistCakedayEnabled < ActiveRecord::Migration[7.2]
+  def up
+    # 5 is bool data_type
+    DB.exec <<~SQL
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES('cakeday_enabled', 5, 't', NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
…so it can be changed in the future, to `false`, when the plugin is merged into core.