### PR TITLE
DEV: Persist the current value of `cakeday_birthday_enabled`

### DIFF
--- a/db/migrate/20250811132217_persist_cakeday_birthday_enabled.rb
+++ b/db/migrate/20250811132217_persist_cakeday_birthday_enabled.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# TODO: Comment this migration out when merging the plugin into core
+class PersistCakedayBirthdayEnabled < ActiveRecord::Migration[8.0]
+  def up
+    # 5 is bool data_type
+    DB.exec(<<~SQL, value: SiteSetting.cakeday_birthday_enabled ? "t" : "f")
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES('cakeday_birthday_enabled', 5, :value, NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
…so that the default could be changed in the future.

(similar to 2325c95ece7b79053b98c5bb4855e84d51e96cc1)